### PR TITLE
pass cookies as event object

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,9 +1,17 @@
 // config.js
 
 let config = {
-  apiKey: process.env.API_KEY || null,
-  hostname: process.env.HOSTNAME || null,
-  protocol: process.env.PROTOCOL || 'https',
+  apiKey: null,
+  hostname: null,
+  protocol: 'https',
 };
+
+if (typeof process !== 'undefined') {
+  config = {
+    apiKey: process.env.API_KEY || null,
+    hostname: process.env.HOSTNAME || null,
+    protocol: process.env.PROTOCOL || 'https',
+  };
+}
 
 module.exports = config;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,4 @@
 // index.js
-
-const { merge } = require('webpack-merge');
 const config = require('./config.js');
 let identifierParams = {};
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueshift-js",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "Event tracking library for the Blueshift marketing platform.",
   "main": "dist/main.js",
   "scripts": {

--- a/util.js
+++ b/util.js
@@ -81,7 +81,6 @@ function generateRequestUrl(protocol, hostname, apiKey, event, obj) {
 
   // Strategy for non-browser environment
   function generateNonBrowserRequest() {
-    debugger;
     const eventObjKeys = Object.keys(obj);
     const remainingAttrs = { ...obj };
 

--- a/util.test.js
+++ b/util.test.js
@@ -64,8 +64,52 @@ describe('generateRequestUrl for Browser', () => {
   });
 
   afterEach(() => {
-    // restore the spy created with spyOn
     jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    // Set document and window to undefined
+    global.document = undefined;
+    global.window = undefined;
+  });
+
+  it('should throw error if required parameters are missing', () => {
+    expect(() =>
+      generateRequestUrl(
+        null,
+        TEST_HOSTNAME,
+        TEST_API_KEY,
+        TEST_EVENT,
+        TEST_PROPERTIES
+      )
+    ).toThrow('Missing required parameters.');
+    expect(() =>
+      generateRequestUrl(
+        'https',
+        null,
+        TEST_API_KEY,
+        TEST_EVENT,
+        TEST_PROPERTIES
+      )
+    ).toThrow('Missing required parameters.');
+    expect(() =>
+      generateRequestUrl(
+        'https',
+        TEST_HOSTNAME,
+        null,
+        TEST_EVENT,
+        TEST_PROPERTIES
+      )
+    ).toThrow('Missing required parameters.');
+    expect(() =>
+      generateRequestUrl(
+        'https',
+        TEST_HOSTNAME,
+        TEST_API_KEY,
+        null,
+        TEST_PROPERTIES
+      )
+    ).toThrow('Missing required parameters.');
   });
 
   it('should generate request URL for browser environment', () => {
@@ -101,5 +145,73 @@ describe('generateRequestUrl for Browser', () => {
     expect(url).toContain('&k=');
     expect(url).toContain('&email=test%40test.com');
     expect(url).toContain('&prop1=value1');
+  });
+});
+
+describe('generateRequestUrl for Non-Browser', () => {
+  const TEST_API_KEY = 'test-api-key';
+  const TEST_HOSTNAME = 'api.test.com';
+  const TEST_EVENT = 'test_event';
+  const TEST_PROPERTIES = {
+    email: 'test@test.com',
+    prop1: 'value1',
+    cookie: 'test-cookie',
+    referrer: 'test-referrer',
+  };
+
+  it('should throw error if required parameters are missing', () => {
+    expect(() =>
+      generateRequestUrl(
+        null,
+        TEST_HOSTNAME,
+        TEST_API_KEY,
+        TEST_EVENT,
+        TEST_PROPERTIES
+      )
+    ).toThrow('Missing required parameters.');
+    expect(() =>
+      generateRequestUrl(
+        'https',
+        null,
+        TEST_API_KEY,
+        TEST_EVENT,
+        TEST_PROPERTIES
+      )
+    ).toThrow('Missing required parameters.');
+    expect(() =>
+      generateRequestUrl(
+        'https',
+        TEST_HOSTNAME,
+        null,
+        TEST_EVENT,
+        TEST_PROPERTIES
+      )
+    ).toThrow('Missing required parameters.');
+    expect(() =>
+      generateRequestUrl(
+        'https',
+        TEST_HOSTNAME,
+        TEST_API_KEY,
+        null,
+        TEST_PROPERTIES
+      )
+    ).toThrow('Missing required parameters.');
+  });
+
+  it('should set cookie and generate url for non-browser environment', () => {
+    const url = generateRequestUrl(
+      'https',
+      TEST_HOSTNAME,
+      TEST_API_KEY,
+      TEST_EVENT,
+      TEST_PROPERTIES
+    );
+
+    expect(url).toContain('&prop1=value1');
+    expect(url).toContain('https://api.test.com/unity.gif?x=test-api-key');
+    expect(url).toContain('&e=test_event');
+    expect(url).toContain('&k=test-cookie');
+    expect(url).toContain('&email=test%40test.com');
+    expect(url).toContain('&r=test-referrer');
   });
 });


### PR DESCRIPTION
- In Shopify we pixel extension we don't have access to the `window` or `document` object. This prohibits us from using the `getCookie` or `setCookie` function in such environments.

- With the changes in this PR, we can pass in `cookies`, `referrer` or `url` as part of the event object and pass those in to events api query params.